### PR TITLE
Use Props instead of manual text to render `LabelTitle` text

### DIFF
--- a/src/components/LabelTitle/index.js
+++ b/src/components/LabelTitle/index.js
@@ -1,29 +1,45 @@
 import React from "react"
+import PropTypes from 'prop-types'
 import styles from "./styles.module.css"
+
 const LabelTitle = props => {
   return (
     <div className={styles.labelTitle}>
       <h1 className={styles.headertTitle}>Data Nutrition Label</h1>
-      <h1 className={styles.datasetLabel}>College Scoreboard Dataset 2020</h1>
+      <h1 className={styles.datasetLabel}>{props.datasetName}</h1>
       <div className={styles.link}>
         <h2 className={styles.datasetNameLink}></h2>
       </div>
       <div className={styles.link}>
-        <a className={styles.datasetBoldLink} href="#">
+        <a className={styles.datasetBoldLink} href={props.datasetNameLink}>
           <img src="/linkimg.png" alt="" id="datasetLink" />
         </a>
       </div>
       <div className={styles.link}>
-        <p className={styles.datasetOriginLink}>US Department of Education</p>
+        <p className={styles.datasetOriginLink}>{props.datasetOrg}</p>
       </div>
       <div className={styles.link}>
-        <a className={styles.datasetLink} href="#">
+        <a className={styles.datasetLink} href={props.datasetOrgLink}>
           <img src="/linkimg.png" alt="" id="datasetLink" />
         </a>
       </div>
       <span className={styles.weightedLine}> </span>
     </div>
   )
+}
+
+LabelTitle.propTypes = {
+  datasetName: PropTypes.string.isRequired,
+  datasetOrg: PropTypes.string.isRequired,
+  datasetNameLink: PropTypes.string.isRequired,
+  datasetOrgLink: PropTypes.string.isRequired
+}
+
+LabelTitle.defaultProps = {
+  datasetName: 'College Scoreboard Dataset 2020',
+  datasetOrg: 'US Department of Education',
+  datasetNameLink: '#',
+  datasetOrgLink: '#'
 }
 
 export default LabelTitle


### PR DESCRIPTION
This resolves issues #27 by:
- Adding default props to the component
- Adding propTypes to the component
- Using props to render the names of the org and dataset, rather than default text