### PR TITLE
Adjust label wrapper layout

### DIFF
--- a/src/components/LabelMenus/styles.module.css
+++ b/src/components/LabelMenus/styles.module.css
@@ -64,4 +64,14 @@
   .menuTitle {
     font-size: 0.8rem;
   }
+
+  .menuTop {
+    margin-bottom: 1rem;
+  }
+
+  .labelMenu {
+    display: flex;
+    justify-content: space-around;
+    padding: 0;
+  }
 }

--- a/src/components/LabelWrapper/index.js
+++ b/src/components/LabelWrapper/index.js
@@ -25,25 +25,28 @@ class LabelWrapper extends Component {
         {this.props.label.overview === undefined ? (
           []
         ) : (
-          <div key={1} className={styles.flexComponents}>
+          <div key={1}>
             <Col
               className={styles.flexTitleMenus}
-              xl={{ span: 2 }}
-              md={{ span: 2 }}
+              xl={{ span: 2, offset: 1 }}
+              md={{ span: 2, offset: 1 }}
               sm={{ span: 12 }}
             >
-              <LabelMenus />
-              <ShareButton />
+              <LabelMenus />     
             </Col>
             <Col
               className={styles.sectionBase}
-              xl={{ span: 10, offset: 2 }}
-              md={{ span: 10, offset: 2 }}
+              xl={{ span: 8, offset: 3 }}
+              md={{ span: 8, offset: 3 }}
               sm={{ span: 12 }}
             >
               <div className={styles.labelHeader}>
-                <h2>Dataset Nutrition Label</h2>
-                <h4>{this.props.label.overview.summary.datasetName}</h4>
+                <h1>Dataset Nutrition Label</h1>
+                <div>
+                  <h4>{this.props.label.overview.summary.datasetName}</h4>
+                  <p>{this.props.label.overview.summary.createdBy}</p>
+                </div>
+                <ShareButton />
               </div>
               {this.props.base === "OVERVIEW" ? (
                 <Overview

--- a/src/components/LabelWrapper/styles.module.css
+++ b/src/components/LabelWrapper/styles.module.css
@@ -4,13 +4,11 @@
 @value landscapeMaxWidth from layout;
 @value portraitMaxWidth from layout;
 
-.labelWrapper {
-  padding: 1.5rem 2.5rem;
-}
+@value lightGray from layout;
 
-.flexComponents {
-  display: flex;
-  flex-direction: row;
+.labelWrapper {
+  padding: 1.5rem 0;
+  background-color: lightGray;
 }
 
 .flexTitleMenus {
@@ -28,16 +26,19 @@
   border-right: solid 0.2rem #000;
   border-left: solid 0.2rem #000;
   border-bottom: solid 0.2rem #000;
+  background-color: #fff;
   margin-top: 2.1875rem;
   padding: 2.6875rem;
 }
 
 .labelHeader {
-  border-bottom: solid .5rem black;
+  display: flex;
+  justify-content: space-between;
+  border-bottom: solid 1rem black;
   margin-bottom: 2rem;
 }
 
-.labelHeader h2,
+.labelHeader h1,
 .labelHeader h4 {
     margin-bottom: 0;
 }
@@ -51,7 +52,17 @@
 }
 
 @media (max-width: landscapeMaxWidth) {
-    .flexTitleMenus {
+    .labelWrapper {
+        padding: 1rem 0;
+    }
 
+    .sectionBase {
+        margin-top: .5rem;
+    }
+
+    .flexTitleMenus {
+        position: relative;
+        margin-top: 0;
+        padding-right: 0;
     }
 }

--- a/src/components/ShareButton/index.js
+++ b/src/components/ShareButton/index.js
@@ -6,7 +6,7 @@ const ShareButton = () => {
   return (
     <div className={styles.buttonSpacing}>
       <Button variant="primary" size="lg" className={styles.buttonStyle}>
-        <p className={styles.buttonText}>Download PDF</p>
+        <span className={styles.buttonText}>Download PDF</span>
       </Button>
     </div>
   )

--- a/src/components/ShareButton/styles.module.css
+++ b/src/components/ShareButton/styles.module.css
@@ -1,16 +1,17 @@
 @value layout: "../layout.css";
 
+@value landscapeMaxWidth from layout;
+
 @value sideSectionPadding from layout;
 @value darkSlateBlue from layout;
 @value teal: #1ABC9C;
 
 .buttonSpacing {
-  padding: 1rem 0 0 0;
+  padding: 0;
   text-align: right;
 }
 
 .buttonStyle {
-  height: 30px;
   background-color: darkSlateBlue;
   border: 1px;
   border-radius: 1px;
@@ -20,7 +21,7 @@
   padding: 0;
   position: relative;
   bottom: 4px;
-  font-size: 0.94rem;
+  font-size: 1rem;
   text-align: center;
   vertical-align: middle;
 }
@@ -32,4 +33,10 @@
 .buttonStyle:active,
 .buttonStyle:visited {
   background-color: darkSlateBlue !important;
+}
+
+@media (max-width: landscapeMaxWidth) {
+    .buttonSpacing {
+        display: none;
+    }
 }

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -28,8 +28,8 @@ h2,
 h3,
 h4,
 h5 {
-    color: #444;
-    font-weight: 600;
+    color: #000;
+    font-weight: 800;
     line-height: 1.5;
     margin: 0 0 2rem 0;
 }


### PR DESCRIPTION
Based on updated mocks, this updates the label wrapper to:
1. take up less space on the screen
2. have a gray background color outside the label
3. update the title size, and position of subtitle
4. update the color of headers to be black
5. Move the download button into the label