### PR TITLE
Implement GH-64 part 1: Update overview section

### DIFF
--- a/src/components/_Labels_/Overview/index.js
+++ b/src/components/_Labels_/Overview/index.js
@@ -17,10 +17,10 @@ const SEVERITY_MAP = {
 
 // colors for severty in same order as above
 const COLOR_MAP = [
-  colors.alertRed,
-  colors.alertOrange,
-  colors.alertYellow,
-  colors.alertBlue,
+  colors.teal,
+  colors.teal,
+  colors.teal,
+  colors.teal,
 ]
 
 class Overview extends Component {
@@ -47,24 +47,24 @@ class Overview extends Component {
       mark: "rect",
       width: "container",
       encoding: {
-        y: {
+        x: {
           field: "severity",
           type: "nominal",
-          sort: ["HIGH", "MED", "LOW", "FYI"],
+          sort: ["FYI", "LOW", "MED", "HIGH",],
         },
-        x: { field: "type", type: "nominal" },
+        y: { field: "type", type: "nominal" },
         opacity: {
           aggregate: "count",
           field: "severity",
           scale: {
             type: "threshold",
             domain: [1, 5, 15],
-            range: [0.2, 0.4, 0.6, 1.0],
+            range: [0.05, 0.2, 0.5, 1.0],
           },
           legend: {
             title: "Number of Alerts",
-            titleFontSize: 14,
-            labelFontSize: 14,
+            titleFontSize: 16,
+            labelFontSize: 16,
           },
         },
         color: {
@@ -83,7 +83,7 @@ class Overview extends Component {
         axis: {
           grid: true,
           tickBand: "extent",
-          labelFontSize: "12",
+          labelFontSize: "14",
           titleFontSize: 0,
         },
         legend: {
@@ -109,69 +109,8 @@ class Overview extends Component {
   render() {
     return (
       <>
-        <Row className={styles.row}>
-          <Col md={5}>
-            <h3 className={styles.sectionTitle}>Summary</h3>
-            <span className={styles.datasetUnderline} />
-            <div className={styles.summaryCreationSection}>
-              <div className={styles.summaryRow}>
-                <span className={styles.summaryLabel}>Created By:</span>
-                <ReactMarkdown>
-                  {this.props.summary.createdBy +
-                    ", " +
-                    this.props.summary.creatorContactInfo}
-                </ReactMarkdown>
-              </div>
-              <div className={styles.summaryRow}>
-                <span className={styles.summaryLabel}>
-                  Data Creation Range:
-                </span>
-                <ReactMarkdown>
-                  {this.props.summary.dataCollectionRange}
-                </ReactMarkdown>
-              </div>
-              <div className={styles.summaryRow}>
-                <span className={styles.summaryLabel}>Publish Date:</span>
-                <ReactMarkdown>
-                  {this.props.summary.datasetPublishDate}
-                </ReactMarkdown>
-              </div>
-              <div className={styles.summaryRow}>
-                <span className={styles.summaryLabel}>Update Frequency:</span>
-                <ReactMarkdown>
-                  {this.props.summary.datasetUpdateFrequency}
-                </ReactMarkdown>
-              </div>
-              <div className={styles.summaryRow}>
-                <span className={styles.summaryLabel}>
-                  Most Recent Label Update:
-                </span>
-                <ReactMarkdown>
-                  {this.props.summary.lastLabelUpdate}
-                </ReactMarkdown>
-              </div>
-              <div className={styles.summaryRow}>
-                <span className={styles.summaryLabel}>License:</span>
-                <ReactMarkdown>{this.props.summary.licenseInfo}</ReactMarkdown>
-              </div>
-              <div className={styles.summaryRow}>
-                <span className={styles.summaryLabel}>Size:</span>
-                <ReactMarkdown>{this.props.summary.datasetSize}</ReactMarkdown>
-              </div>
-              <div className={styles.summaryRow}>
-                <span className={styles.summaryLabel}>Format:</span>
-                <ReactMarkdown>
-                  {this.props.summary.datasetFormat}
-                </ReactMarkdown>
-              </div>
-              <div className={styles.summaryRow}>
-                <span className={styles.summaryLabel}>Source URL:</span>
-                <ReactMarkdown>{this.props.summary.sourceURL}</ReactMarkdown>
-              </div>
-            </div>
-            <ReactMarkdown source={this.props.summary.summaryText} />
-          </Col>
-          <Col md={{ span: 6, offset: 1 }}>
+        <Row className={styles.row}>     
+          <Col md={{ span: 6 }}>
             <h3 className={styles.sectionTitle}>About</h3>
             <span className={styles.datasetUnderline} />
             <div className={styles.qAndA}>
@@ -181,9 +120,7 @@ class Overview extends Component {
               />
             </div>
           </Col>
-        </Row>
-        <Row>
-          <Col md={5}>
+          <Col md={{ span: 5, offset: 1 }}>
             <h3 className={styles.sectionTitle}>Top Use Cases</h3>
             <span className={styles.datasetUnderline} />
             {this.props.topUseCases.map((useCaseName, i) => (
@@ -200,10 +137,97 @@ class Overview extends Component {
               </Row>
             ))}
           </Col>
-          <Col md={{ span: 6, offset: 1 }}>
+        </Row>
+        <Row>
+          <Col md={6}>
+            <h3 className={styles.sectionTitle}>Summary</h3>
+            <span className={styles.datasetUnderline} />
+            <div className={styles.summaryCreationSection}>
+              <div className={styles.primarySummary}>
+                <div className={styles.summaryRow}>
+                  <Col md={6} className={styles.summaryLabel}>Created By:</Col>
+                  <Col md={6}>
+                    <ReactMarkdown>
+                      {this.props.summary.createdBy +
+                        ", " +
+                        this.props.summary.creatorContactInfo}
+                    </ReactMarkdown>
+                  </Col>
+                </div>
+                <div className={styles.summaryRow}>
+                  <Col md={6} className={styles.summaryLabel}>
+                    Data Creation Range:
+                  </Col>
+                  <Col md={6}>
+                    <ReactMarkdown>
+                      {this.props.summary.dataCollectionRange}
+                    </ReactMarkdown>
+                  </Col>
+                </div>
+                <div className={styles.summaryRow}>
+                  <Col md={6} className={styles.summaryLabel}>Publish Date:</Col>
+                  <Col md={6}>
+                    <ReactMarkdown>
+                      {this.props.summary.datasetPublishDate}
+                    </ReactMarkdown>
+                  </Col>
+                </div>
+                <div className={styles.summaryRow}>
+                  <Col md={6} className={styles.summaryLabel}>Update Frequency:</Col>
+                  <Col md={6}>
+                    <ReactMarkdown>
+                      {this.props.summary.datasetUpdateFrequency}
+                    </ReactMarkdown>
+                  </Col>
+                </div>
+                <div className={styles.summaryRow}>
+                  <Col md={6} className={styles.summaryLabel}>
+                    Most Recent Label Update:
+                  </Col>
+                  <Col md={6}>
+                    <ReactMarkdown>
+                      {this.props.summary.lastLabelUpdate}
+                    </ReactMarkdown>
+                  </Col>
+                </div>
+              </div>
+              <div className={styles.secondarySummary}>
+                <div className={styles.summaryRow}>
+                  <Col md={6} className={styles.summaryLabel}>License:</Col>
+                  <Col md={6}>
+                    <ReactMarkdown>{this.props.summary.licenseInfo}</ReactMarkdown>
+                  </Col>
+                </div>
+                <div className={styles.summaryRow}>
+                  <Col md={6} className={styles.summaryLabel}>Size:</Col>
+                  <Col md={6}>
+                    <ReactMarkdown>{this.props.summary.datasetSize}</ReactMarkdown>
+                  </Col>
+                </div>
+                <div className={styles.summaryRow}>
+                  <Col md={6} className={styles.summaryLabel}>Format:</Col>
+                  <Col md={6}>
+                    <ReactMarkdown>
+                      {this.props.summary.datasetFormat}
+                    </ReactMarkdown>
+                  </Col>
+                </div>
+                <div className={styles.summaryRow}>
+                  <Col md={6} className={styles.summaryLabel}>Source URL:</Col>
+                  <Col md={6}>
+                    <ReactMarkdown>{this.props.summary.sourceURL}</ReactMarkdown>
+                  </Col>
+                </div>
+              </div>
+            </div>
+            <ReactMarkdown source={this.props.summary.summaryText} />
+          </Col>    
+          <Col md={{ span: 5, offset: 1 }}>
             <h3 className={styles.sectionTitle}>Alerts</h3>
             <span className={styles.datasetUnderline} />
-            {this.renderAlertsChart()}
+            <div className={styles.alertSection}>
+              {this.renderAlertsChart()} 
+            </div>
           </Col>
         </Row>
       </>

--- a/src/components/_Labels_/Overview/styles.module.css
+++ b/src/components/_Labels_/Overview/styles.module.css
@@ -19,9 +19,28 @@
   margin-bottom: 1.5rem;
 }
 
+.summaryRow {
+  display: flex;
+}
+
+.summaryLabel {
+  text-align: right;
+}
+
 .summaryRow,
 .summaryRow p {
   margin-bottom: .125rem;
+}
+
+.primarySummary {
+  font-size: 1rem;
+  line-height: 1;
+  margin-bottom: 1rem;
+}
+
+.secondarySummary {
+  font-size: .85rem;
+  line-height: 1;
 }
 
 .summaryLabel {
@@ -52,6 +71,11 @@
   font-size: 1.25rem;
 }
 
+.alertSection {
+  display: flex;
+  justify-content: center;
+}
+
 .alertGraph {
-    width: 100%;
+  width: 23.5rem;
 }

--- a/static/blobs/ctp-blob.json
+++ b/static/blobs/ctp-blob.json
@@ -7,8 +7,8 @@
             "datasetUpdateFrequency": "Daily, at 4-5pm EST",
             "lastLabelUpdate": "August 5, 2020",
             "createdBy": "COVID Tracking Project, The Atlantic",
-            "creatorContactInfo": "<https://covidtracking.com/contact>",
-            "licenseInfo": "Creative Commons, <https://covidtracking.com/about-data/license>",
+            "creatorContactInfo": "([Contact](https://covidtracking.com/contact))",
+            "licenseInfo": "Creative Commons, ([more information here](https://covidtracking.com/about-data/license))",
             "datasetSize": "34 KB",
             "datasetFormat": "Tabular (csv, JSON)",
             "sourceURL": "<https://covidtracking.com/data/api>"
@@ -17,7 +17,9 @@
             "bending-curve",
             "back-to-normal",
             "outbreak-clusters",
-            "population-based-impact"
+            "population-based-impact",
+            "exceed-hospital-capacity",
+            "point-prevalence"
         ]
     },
     "dataset-info": {
@@ -26,7 +28,7 @@
                 "question": "Tell us about this dataset.",
                 "help": "Please provide an overview of this dataset.",
                 "type": "markdown",
-                "answer": "This Dataset is comprised of US state level data for Covid-19. All of the data is taken directly from the websites of state/territory public health authorities, and includes, by state: positive and negative cases, pending results, current and cumulative hospitalizations, cumultive and current patients in ICUs, cumulative and current patients on ventilators, total recovered, and total deaths. We compile these numbers to provide the most complete picture we can assemble of the US COVID-19 testing effort and the outbreak’s effects on the people and communities it strikes. The data is updated daily between 4-5 pm. From FAQ: \"See our data sources page or flip to the \"States\" tab of our public spreadsheet, which includes constantly updated annotations about data-source changes.\""
+                "answer": "This Dataset is comprised of US state level data for Covid-19. All of the data is taken directly from the websites of state/territory public health authorities, and includes, by state: positive and negative cases, pending results, current and cumulative hospitalizations, cumultive and current patients in ICUs, cumulative and current patients on ventilators, total recovered, and total deaths. The Covid Tracking Project compiles these numbers to provide the most complete picture they can assemble of the US COVID-19 testing effort and the outbreak’s effects on the people and communities it strikes. The data is updated daily between 4-5 pm. From FAQ: \"See our data sources page or flip to the \"States\" tab of our public spreadsheet, which includes constantly updated annotations about data-source changes.\""
             },
             {
                 "question": "Is there an intended purpose for the dataset? What domain was it designed for?",


### PR DESCRIPTION
This implements part 1 of the redesigns, as outlined in #64. This does not include the arrows (which will be added later), but does include the changes as to where things are placed, and styling changes.