### PR TITLE
First draft: TaxBills Dataset Label

### DIFF
--- a/src/pages/labels/taxbills-nyc.js
+++ b/src/pages/labels/taxbills-nyc.js
@@ -1,0 +1,15 @@
+import React from "react"
+import { Provider } from "react-redux"
+
+import LabelWrapper from "../../components/LabelWrapper/index.js"
+import Header from "../../components/header/index.js"
+import store from "../../store/index"
+
+const TaxBillsPage = () => (
+  <Provider store={store}>
+    <Header />
+    <LabelWrapper jsonFile="taxbills-blob" />
+  </Provider>
+)
+
+export default TaxBillsPage

--- a/static/blobs/taxbills-blob.json
+++ b/static/blobs/taxbills-blob.json
@@ -1,0 +1,985 @@
+{
+   "overview": {
+        "summary": {
+            "datasetName": "TaxBills NYC Dataset (joined.csv)",
+            "dataCollectionRange": "January, 2015 - Present",
+            "datasetPublishDate": "Unknown",
+            "datasetUpdateFrequency": "Yearly",
+            "lastLabelUpdate": "August 5, 2020",
+            "createdBy": "John Krauss",
+            "creatorContactInfo": "([Github page](https://github.com/talos))",
+            "licenseInfo": "Creative Commons Attribution Share-Alike (see [here](https://github.com/talos/nyc-stabilization-unit-counts#nyc-stabilization-unit-counts) for more info)",
+            "datasetSize": "9.8 MB",
+            "datasetFormat": "Tabular (csv, JSON)",
+            "sourceURL": "<https://github.com/talos/nyc-stabilization-unit-counts>"
+        },
+        "top-use-cases": [
+            "units-building",
+            "units-building-lost",
+            "deregulation-building",
+            "deregulation-landlord",
+            "gentrification"
+        ]
+    },
+   "dataset-info": {
+        "description": [
+            {
+                "question": "Tell us about this dataset. ",
+                "help": "Please provide an overview of this dataset.",
+                "type": "markdown",
+                "answer": "This dataset was created to make information about NYC's rent stabilized apartments more accessible to the public. Currently, information on rent stabilization in NYC is only published in aggregate by borough, leaving little information about specific buildings available. By parsing tax bill data about buildings contained in Notice of Property Value (NoPV) documents, which are available publicly in pdf format, this dataset is able to get a building-by-building count of rent stabilized units in NYC. **See more about why this dataset was created [here](http://blog.johnkrauss.com/betanyc-stabilization-presentation/).**"
+            },
+            {
+                "question": "Is there an intended purpose for the dataset? What domain was it designed for? ",
+                "help": "For example, is there a service or organization that leverages this dataset? Is this dataset made available for a certain use in mind?",
+                "type": "markdown",
+                "answer": "See [here](http://blog.johnkrauss.com/betanyc-stabilization-presentation/#38) for information on intended purposes from the dataset creator. Some intended purposes include:\n1. Seeing loss of rent stabilized units over time in a building\n2. Seeing loss of rent stabilized units over time in many buildings"
+            },
+            {
+                "question": "What is the license under which the dataset is made available? ",
+                "help": "If possible, please link to license description. ",
+                "type": "markdown",
+                "answer": "Creative Commons Attribution Share-Alike"
+            },
+            {
+                "question": "Are there any additional restrictions under which the dataset is made available? Are there any legislation, codes of practice or guidance from the jurisdiction or domain in which the data was collected about the use of this data? Are there tasks for which the dataset cannot be used? Please provide a description or guidance. ",
+                "help": "The purpose of this question is to highlight any information pertinent to data practitioners who may wish to leverage this dataset in their work. This should include any legal restrictions, usage restrictions, license restrictions.",
+                "type": "markdown",
+                "answer": "No"
+            },
+            {
+                "question": "Are there tasks for which the dataset would be cautioned against being used? If so, please provide a description. ",
+                "help": "For example, use cases that are known to be problematic, such as a generalized use case that highlights historical or systematic issues in the dataset. ",
+                "type": "markdown",
+                "answer": "No"
+            },
+            {
+                "question": "Has the dataset been used for any tasks already? If so, please provide a description and links to papers or systems using the dataset",
+                "help": "Note that for mature datasets, this could be a long list. Feel free to identify types or categories rather than list every known implementation. ",
+                "type": "markdown",
+                "answer": "1. Changes in Rent Stabilization Visualization: <https://docker4data.carto.com/viz/766a0f32-1ea1-11e5-b267-0e49835281d6/public_map>\n2. Who Owns What lookup tool: <https://whoownswhat.justfix.nyc/>"
+            }
+        ],
+        "provenance": [
+            {
+                "question": "Who created the dataset and on behalf of which entity?",
+                "help": "e.g. which team or research group on behalf of which company, institution, organization?",
+                "type": "markdown",
+                "answer": "This dataset was scraped by individuals as part of a volunteer effort led by John Krauss <http://blog.johnkrauss.com/>. The people involved are anti-displacement activists who did this without funding or direction of a specific entity."
+            },
+            {
+                "question": "How is / was the collection and management of this dataset funded? ",
+                "help": "",
+                "type": "markdown",
+                "answer": "This dataset was scraped by individuals as part of a volunteer effort led by John Krauss <http://blog.johnkrauss.com/>. The people involved are anti-displacement activists who did this without funding or direction of a specific entity."
+            }
+        ],
+        "collection": [
+            {
+                "question": "Over what timeframe was the data collected? If the data continues to be updated, please indicate. ",
+                "help": "",
+                "type": "markdown",
+                "answer": "The dataset collects yearly information, and is therefore updated yearly. It has recorde for each instance dating back to 2008."
+            },
+            {
+                "question": "What mechanisms or procedures were used to collect the data?",
+                "help": "e.g. Manual curation of data, software API, hardware apparatus or sensor",
+                "type": "markdown",
+                "answer": "See the [github repository](https://github.com/talos/nyc-stabilization-unit-counts) for the dataset for more information. The scraper which goes through the original tax bills (Notice of Property Value PDFs) is contained within that repository."
+            },
+            {
+                "question": "What is the relationship between the dataset collector and owners or managers of the dataset?",
+                "help": "",
+                "type": "markdown",
+                "answer": "The original dataset is a set of tax documents published by a government agency. That data has been preprocessed and cleaned by the volunteers who have made this dataset."
+            },
+            {
+                "question": "If individuals' data is included in this dataset, did those individuals consent to the collection and use of their data? If so, please describe consent procedure.",
+                "help": "",
+                "type": "markdown",
+                "answer": "N/A"
+            },
+            {
+                "question": "If individuals' data is included in this dataset, was this data altered to ensure higher levels of privacy? If yes, please describe any privacy procedures followed with regards to this dataset (anonymization efforts, privacy protocols, supression techniques, etc). ",
+                "help": "If sensitive, feel free to describe these procedures at a high level. ",
+                "type": "markdown",
+                "answer": "N/A"
+            },
+            {
+                "question": "Has the data been reviewed for quality?",
+                "help": "If so, please provide information about the review process. ",
+                "type": "markdown",
+                "answer": "Yes, data has been reviewed by internal team"
+            },
+            {
+                "question": "Were any ethical review processes conducted (e.g., by an institutional review board)? If so, please provide a description of these review processes, including the outcomes, as well as a link or other access point to any supporting documentation.",
+                "help": "If so, please provide information about the review process. ",
+                "type": "markdown",
+                "answer": "No"
+            }
+        ],
+        "management": [
+            {
+                "question": "How is the data being mananged at rest and in transit?",
+                "help": "Particularly with regards to encryption at rest and in transit, access controls on internal users and third parties, access logs, and up-to-date software. ",
+                "type": "markdown",
+                "answer": "Through a third-party data service, terms and conditions ensure users data should be protected from theft, misuse, or data corruption"
+            },
+            {
+                "question": "How can the data be accessed? If this is going to change over time, please indicate this. ",
+                "help": "Please indicte permanent URL location or method by which data can be accessed. ",
+                "type": "markdown",
+                "answer": "Data can be accessed at <http://taxbills.nyc/>, or on github at <https://github.com/talos/nyc-stabilization-unit-counts>."
+            },
+            {
+                "question": "Will the dataset be distributed to any other individuals/third parties (e.g. companies, institutions, organizations)? If yes, when will the dataset be distributed and how will the dataset be distributed (e.g. GitHub, tarball on the website, etc)?",
+                "help": "",
+                "type": "markdown",
+                "answer": "No"
+            },
+            {
+                "question": "Will the dataset be updated (e.g., to correct labeling errors, add new instances, delete instances)? If so, please describe how often, by whom, and how updates will be communicated to users (e.g., mailing list, GitHub)?",
+                "help": "",
+                "type": "markdown",
+                "answer": "Data is updated yearly. Date of update is unknown."
+            },
+            {
+                "question": "Is there a mechanism through which an individual can request their personal information be removed?",
+                "help": "",
+                "type": "markdown",
+                "answer": "N/A"
+            }
+        ],
+        "composition": [
+            {
+                "question": "Does the dataset have a metadata repository or data dictionary? If yes, please provide the link and if not, please explain what each field means.",
+                "help": "The purpose of this question is to enable data practitioners to understand what is contained in the dataset at a field level. ",
+                "type": "markdown",
+                "answer": "See the [github repository](https://github.com/talos/nyc-stabilization-unit-counts) for this dataset for a data dictionary, which is contained in its readme."
+            },
+            {
+                "question": "In the case of explicitly related instances, are these relationships indicated? \n(e.g., relating an instance about a user to instances about their posts)",
+                "help": "Explicitly related instances refers to instances that include pointers or keys to other instances. If applicable, please describe these relationships or indicate where to find more information. ",
+                "type": "markdown",
+                "answer": "No"
+            },
+            {
+                "question": "What data does each instance consist of? For example, does it consist of raw data (e.g., unprocessed text or images) or features? In either case, please provide a description.",
+                "help": "If this information has been described elsewhere, please indicate where it can be found (e.g. data dictionary). ",
+                "type": "markdown",
+                "answer": "This data contains features that were extracted from another dataset of raw, unprocessed file images. This process is described on the dataset's [github repository](https://github.com/talos/nyc-stabilization-unit-counts), where you can also find source code for how that data is extracted."
+            },
+            {
+                "question": "How many instances are there in total (of each type, if appropriate)?",
+                "help": "The purpose of this question is to enable data practitioners to quickly understand the size or breadth of a dataset. If this is covered in the data dictionary or elsewhere, please indicate where this information can be found. ",
+                "type": "markdown",
+                "answer": "46,462 instances in this dataset."
+            },
+            {
+                "question": "Is there a label or target associated with each instance?",
+                "help": "Please indicate the use of labels / targets. 'Labels' and 'Targets' facilitate the use of the dataset in classification algorithms. You can learn more about this here: https://en.wikipedia.org/wiki/Labeled_data",
+                "type": "markdown",
+                "answer": "From <https://github.com/talos/nyc-stabilization-unit-counts#caveats>: \"The combination of self-reporting stabilization counts and occasionally missing tax bills means that a significant percentage of buildings miss reporting for some years. In order to compensate, all output files contain some estimated counts...\""
+            },
+            {
+                "question": "Is any information missing from individual instances? If so, what is missing and why?",
+                "help": "For example, if a subset of instances have known collection or data fidelity issues due to e.g. collection timeframe gaps, geographical differences, etc.",
+                "type": "markdown",
+                "answer": "Landlords are not required to register stabilized apartments as part of their tax bills reporting, so in some cases this part of an instance's data is estimated. Estimated instances are marked as such in a column labeled `2007est`."
+            },
+            {
+                "question": "Is your dataset a sample? If so, what was the sampling strategy used (e.g. deterministic, probabilistic with specific sampling probabilities), and does it accurately represents the intended output?",
+                "help": "If your dataset is a sample, please describe sampling methodology. If your sample is not representative of the population data, please describe why not (e.g. to cover a more diverse range of instances, because instances were withheld or unavailable).",
+                "type": "markdown",
+                "answer": "No"
+            },
+            {
+                "question": "Was any preprocessing/cleaning/labeling of the data done? If so, please provide a description. ",
+                "help": "e.g., discretization or bucketing, tokenization, part-of-speech tagging, SIFT feature extraction, removal of instances, processing of missing values",
+                "type": "markdown",
+                "answer": "Data was scraped from its original source, and estimated valuse were added where original data was lacking. See <https://github.com/talos/nyc-stabilization-unit-counts#caveats> for more detail."
+            },
+            {
+                "question": "If the data was processed, was the raw data saved in addition to the preprocessed/cleaned/labeled data? If yes, please provide a link to the raw data.",
+                "help": "Data practitioners may want to confirm your preprocessing steps to better understand the final data product. ",
+                "type": "markdown",
+                "answer": "Data from the original PDFs is available with the github repository."
+            },
+            {
+                "question": "Are there recommended data splits? If so, please provide a description of these splits, explaining the rationale behind them.",
+                "help": "Common splits include training, development/validation, testing data.",
+                "type": "markdown",
+                "answer": "No"
+            },
+            {
+                "question": "Are there any errors, sources of noise, or redundancies in the dataset? If so, please provide a description",
+                "help": "",
+                "type": "markdown",
+                "answer": "Landlords are not required to register stabilized apartments as part of their tax bills reporting, so in some cases this part of an instance's data is estimated. Estimated instances are marked as such in a column labeled `2007est`."
+            },
+            {
+                "question": "Does the dataset include information from upstream sources? If so, name these sources, their stability, and any known usage limitations. ",
+                "help": "Upstream sources can include e.g. other datasets, research papers, tweets, websites.",
+                "type": "markdown",
+                "answer": "This data is parsed from NoPVs published by New York City. The original data is stored as individual .pdf files per each tax record. Usage limitations for the original data are that it is not in list-format anywhere - it is only in individual .pdf files per building, and therefore hard to look at. Per year they are stable, once uploaded."
+            },
+            {
+                "question": "If the datastet includes information from upstream sources, is this dataset technically dependent upon those sources? ",
+                "help": "For example, if this dataset pulls data in directly from an external API it is technically dependent upon that upstream source being available. ",
+                "type": "markdown",
+                "answer": "Technically Dependent upon upstream data"
+            },
+            {
+                "question": "Is there confidential data included in this dataset?",
+                "help": "If so, please indicate the nature of the data and for what purpose this data is included. ",
+                "type": "markdown",
+                "answer": "No"
+            },
+            {
+                "question": "Does the dataset identify any subpopulations (e.g., by age, gender)? If yes, please indicate their distributions within the dataset where possible / available.  ",
+                "help": "",
+                "type": "markdown",
+                "answer": "No"
+            }
+        ]
+    },
+    "use-cases-section": {
+        "alerts": {
+            "count-estimates": {
+                "title": "Some stabilized unit counts are estimates",
+                "type": "markdown",
+                "category": "Collection",
+                "tags": [
+                    [
+                        "Socioeconmic Bias",
+                        " Inaccurate Prediction"
+                    ]
+                ],
+                "mitigation": "Dataset provides a mitigation by marking these in the data, so that dataset users can account for them in calculations",
+                "severity": 1.0,
+                "content": "From <https://github.com/talos/nyc-stabilization-unit-counts#caveats>:\"The combination of self-reporting stabilization counts and occasionally missing tax bills means that a significant percentage of buildings miss reporting for some years.\n\nIn order to compensate, all output files contain some estimated counts. You can exclude these estimates in your own aggregations by replacing those unit counts with 0.If there is no stabilized unit count for a building that had one the previous year, the previous year's number is used in any of the following cases: 1) The bill without a unit count had a SCRIE or DRIE abatement, indicating the continued presence of regulated units. 2) The bill without a unit count maintained the same abatements as the previous year (for example 421a or J51) indicating that restrictions mandating affordability remained in effect. 3) The building appeared on HCR's stabilized building list for the year without a unit count, indicating that it was in fact still stabilized.\""
+            },
+            "true-owner": {
+                "title": "Owner listed is not always the true person/company that owns the lot",
+                "type": "markdown",
+                "category": "Provenance",
+                "tags": [
+                    [
+                        "Misrepresentation"
+                    ]
+                ],
+                "mitigation": "One would need to do some serious digging into public records to identify \"true ownership\", which itself is a subjective definition that is not easily defined from public records without human intervention. However, company ownership is a matter of public record, so this information can be identified.",
+                "severity": 2.0,
+                "content": "Owners listed are often LLCs, which may or may not be the true owning company, since operating LLCs are at times set up externally in order to reduce owner liability directly."
+            },
+            "zipcode-redlining": {
+                "title": "Zipcode is highly correlated with racial demographics in the US",
+                "type": "markdown",
+                "category": "Composition",
+                "tags": [
+                    [
+                        "Racial bias"
+                    ]
+                ],
+                "mitigation": "Do not use zipcode as a main feature in prediction algorithms, unless specifically looking to address racial bias.",
+                "severity": 1.0,
+                "content": "Due to existing [segregation in the US](https://files.consumerfinance.gov/f/201409_cfpb_report_proxy-methodology.pdf), zip code information is correlated with racial demographics, and can unintentionally perpetuate [redlining](https://www.investopedia.com/terms/r/redlining.asp) if not taken into account."
+            }
+        },
+        "fyis": {
+            "existing-use-case": {
+                "title": "Existing Use Cases",
+                "type": "markdown",
+                "category": "Description",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "1. Changes in Rent Stabilization Visualization: <https://docker4data.carto.com/viz/766a0f32-1ea1-11e5-b267-0e49835281d6/public_map>\n2. Who Owns What lookup tool: <https://whoownswhat.justfix.nyc/>\n3. Other use cases listed on the github repository for the dataset: <https://github.com/talos/nyc-stabilization-unit-counts>"
+            },
+            "volunteer-funded": {
+                "title": "Volunteer funded",
+                "type": "markdown",
+                "category": "Provenance",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "This dataset was scraped by individuals as part of a volunteer effort led by John Krauss <http://blog.johnkrauss.com/>. The people involved are anti-displacement activists who did this without funding or direction of a specific entity."
+            },
+            "dataset-not-a-sample": {
+                "title": "Dataset is not a Sample",
+                "type": "markdown",
+                "category": "Completeness",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "This dataset is not a sample."
+            },
+            "raw-data": {
+                "title": "Raw Data",
+                "type": "markdown",
+                "category": "Completeness",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "Data from the original PDFs is available with the github repository."
+            },
+            "upstream-dependence": {
+                "title": "Dataset Dependent upon Upstream Data Sources",
+                "type": "markdown",
+                "category": "Composition",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "This data is parsed from NoPVs published by New York City. The original data is stored as individual .pdf files per each tax record. Usage limitations for the original data are that it is not in list-format anywhere - it is only in individual .pdf files per building, and therefore hard to look at. Per year they are stable, once uploaded."
+            },
+            "no-confidential-data": {
+                "title": "No Confidential Data",
+                "type": "markdown",
+                "category": "Composition",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "There is no confidential data included in this dataset. "
+            },
+            "dataset-populations": {
+                "title": "Dataset Populations",
+                "type": "markdown",
+                "category": "Composition",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "There are no subpopulations identified in this dataset (e.g., by age, gender). "
+            },
+            "collection-timeframe": {
+                "title": "Collection Timeframe",
+                "type": "markdown",
+                "category": "Composition",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "The dataset collects yearly information, and is therefore updated yearly. It has recorde for each instance dating back to 2008."
+            },
+            "collection-organization": {
+                "title": "Collection Organization",
+                "type": "markdown",
+                "category": "Composition",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "The original dataset is a set of tax documents published by a government agency. That data has been preprocessed and cleaned by the volunteers who have made this dataset."
+            },
+            "user-consent": {
+                "title": "User Consent",
+                "type": "markdown",
+                "category": "Collection",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "There is no individual-level data in the dataset, and thus no consent collected. "
+            },
+            "anonymization": {
+                "title": "Anonymization Process",
+                "type": "markdown",
+                "category": "Collection",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "There is no individual-level data in the dataset, and thus no anonymization process. "
+            },
+            "quality-review": {
+                "title": "Quality Review",
+                "type": "markdown",
+                "category": "Collection",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "The data has been reviewed by the team of volunteers who maintain the dataset."
+            },
+            "ethical-review": {
+                "title": "Ethical Review",
+                "type": "markdown",
+                "category": "Collection",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "No institutional review of this dataset has occurred."
+            },
+            "updates": {
+                "title": "Updates",
+                "type": "markdown",
+                "category": "Collection",
+                "tags": [
+                    [
+                        "N/A"
+                    ]
+                ],
+                "content": "Data is updated yearly. Date of update is unknown."
+            }
+        },
+        "predictions": {
+            "per-building": {
+                "description": "% of stabilized units over time for a building",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "per-community": {
+                "description": "% of stabilized units over time for a community district",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "per-zip": {
+                "description": "% of stabilized units over time for a zipcode",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "per-owner": {
+                "description": "% of stabilized units over time for an owner (name)",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "true-owner",
+                        "severity": 1
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "per-building-est": {
+                "description": "Estimated % of stabilized units next year for a building",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "per-community-est": {
+                "description": "Estimated % of stabilized units next year for a community district",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "per-zip-est": {
+                "description": "Estimated % of stabilized units next year for a zipcode",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "per-owner-est": {
+                "description": "Estimated % of stabilized units next year for an owner (name)",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "true-owner",
+                        "severity": 1
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "num-building": {
+                "description": "# of stabilized units over time for a building",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "num-community": {
+                "description": "# of stabilized units over time for a community district",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "num-zip": {
+                "description": "# of stabilized units over time for a zipcode",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "num-owner": {
+                "description": "# of stabilized units over time for an owner (name)",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "true-owner",
+                        "severity": 1
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "num-building-est": {
+                "description": "Estimated # of stabilized units next year for a building",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "num-community-est": {
+                "description": "Estimated # of stabilized units next year for a community district",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "num-zip-est": {
+                "description": "Estimated # of stabilized units next year for a zipcode",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            },
+            "num-owner-est": {
+                "description": "Estimated # of stabilized units next year for an owner (name)",
+                "alerts": [
+                    {
+                        "alert": "count-estimates",
+                        "severity": 2
+                    },
+                    {
+                        "alert": "true-owner",
+                        "severity": 1
+                    },
+                    {
+                        "alert": "zipcode-redlining",
+                        "severity": 2
+                    }
+                ],
+                "fyis": [
+                    "existing-use-case",
+                    "volunteer-funded",
+                    "dataset-not-a-sample",
+                    "raw-data",
+                    "upstream-dependence",
+                    "no-confidential-data",
+                    "dataset-populations",
+                    "collection-timeframe",
+                    "collection-organization",
+                    "user-consent",
+                    "anonymization",
+                    "quality-review",
+                    "ethical-review",
+                    "updates"
+                ]
+            }
+        },
+        "use-cases": {
+            "units-building": {
+                "description": "How many rent stabilized units are in a particular building? ",
+                "predictions": [
+                    "per-building",
+                    "per-building-est",
+                    "num-building",
+                    "num-building-est"
+                ]
+            },
+            "units-building-lost": {
+                "description": "Has a building lost rent stabilized units? ",
+                "predictions": [
+                    "per-building",
+                    "per-building-est",
+                    "num-building",
+                    "num-building-est"
+                ]
+            },
+            "deregulation-building": {
+                "description": "Is there a pattern of deregulation in a building?",
+                "predictions": [
+                    "per-building",
+                    "per-building-est",
+                    "num-building",
+                    "num-building-est"
+                ]
+            },
+            "deregulation-landlord": {
+                "description": "Is there a pattern of deregulation for a specific landlord?",
+                "predictions": [
+                    "per-owner",
+                    "per-owner-est",
+                    "num-owner"
+                ]
+            },
+            "abatement-abuse": {
+                "description": "Where might there be abuse of tax abatements? Is the landlord breaking the rules of the abatements? ",
+                "predictions": [
+                    "per-building",
+                    "per-building-est",
+                    "num-building",
+                    "num-building-est"
+                ]
+            },
+            "gentrification": {
+                "description": "Where is gentrification happening?",
+                "predictions": [
+                    "per-community",
+                    "per-zip",
+                    "per-community-est",
+                    "per-zip-est",
+                    "num-community-est",
+                    "num-zip-est"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR creates a new page for a new label, on the taxbills.nyc dataset in collaboration with JustFix.nyc. This is a first draft of the label content to share with our collaborators for review.