### PR TITLE
Use `break-word` overflow to handle long urls

### DIFF
--- a/src/components/_Labels_/Overview/styles.module.css
+++ b/src/components/_Labels_/Overview/styles.module.css
@@ -17,6 +17,7 @@
 
 .summaryCreationSection {
   margin-bottom: 1.5rem;
+  overflow-wrap: break-word;
 }
 
 .summaryRow {


### PR DESCRIPTION
This fixes a bug that I just noticed in the overview section: when long urls are part of the summary section, they get hidden behind the Alerts visualization. Example:
<img width="661" alt="Screen Shot 2020-11-02 at 2 14 08 PM" src="https://user-images.githubusercontent.com/1815772/97909175-cade0a00-1d15-11eb-9a91-64d214255af2.png">

By adding `break-word` overflow handling, we have:
<img width="635" alt="Screen Shot 2020-11-02 at 2 14 17 PM" src="https://user-images.githubusercontent.com/1815772/97909198-d6c9cc00-1d15-11eb-8e9a-ddcd298b4b62.png">
